### PR TITLE
[ns-gke] Fix node pool instance size. f1-micro no longer supported

### DIFF
--- a/node_pool.tf
+++ b/node_pool.tf
@@ -19,7 +19,7 @@ resource "google_container_node_pool" "custom_nodepool" {
   }
 
   node_config {
-    machine_type    = lookup(each.value, "machine_type", "f1-micro")
+    machine_type    = lookup(each.value, "machine_type", "e2-micro")
     disk_size_gb    = lookup(each.value, "disk_size_gb", 10)
     disk_type       = lookup(each.value, "disk_type", "pd-standard")
     image_type      = lookup(each.value, "image_type", "COS")


### PR DESCRIPTION
Error while terraform applying. f1-micro does not have enough memory to handle gke workload. Using e2-micro as alternative as it is similarly priced and arguably cheaper in some cases